### PR TITLE
Bugfix: could not assign same role_id to user on different reference_…

### DIFF
--- a/src/Kodeine/Acl/Traits/HasRole.php
+++ b/src/Kodeine/Acl/Traits/HasRole.php
@@ -168,7 +168,7 @@ trait HasRoleImplementation
 
             $roleId = $this->parseRoleId($role);
 
-            if (count($this->roles()->where("roles.id",$roleId)->wherePivot('model',$model)->wherePivot('reference_id',$reference_id)->get()) == 0)
+            if (count($this->roles()->where("roles.id",$roleId)->wherePivot('model',$model)->wherePivot('reference_id',$reference_id)->get()) == 0) {
                 $this->roles()->attach($roleId, [
                     'model'        => $model,
                     'reference_id' => $reference_id

--- a/src/Kodeine/Acl/Traits/HasRole.php
+++ b/src/Kodeine/Acl/Traits/HasRole.php
@@ -168,7 +168,7 @@ trait HasRoleImplementation
 
             $roleId = $this->parseRoleId($role);
 
-            if ( ! $this->roles->keyBy('id')->has($roleId) ) {
+            if (count($this->roles()->where("roles.id",$roleId)->wherePivot('model',$model)->wherePivot('reference_id',$reference_id)->get()) == 0)
                 $this->roles()->attach($roleId, [
                     'model'        => $model,
                     'reference_id' => $reference_id


### PR DESCRIPTION
…id. Hence, users could not have the same role on two different models, for example, users could not be project_owner on 2 different projects, since the role was already taken.